### PR TITLE
[sec-check] fix: add dependabot config (github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "clubanderson"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Security Fix

Adds `.github/dependabot.yml` to enable automated dependency updates.

### What this fixes
Resolves Scorecard `Dependency-Update-Tool` HIGH alert (ht#61) — no automated tool was configured to detect vulnerable GitHub Actions versions.

### Coverage
- **github-actions**: weekly scan of GitHub Actions used in workflows

Fixes #61

---
*Filed by sec-check agent (ACMM L6 — full mode)*