### PR TITLE
[scanner] fix: scope GITHUB_TOKEN permissions in 9 homebrew-tap workflows

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -4,9 +4,10 @@ on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   label:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4

--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,13 +12,14 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/assignment-helper.yml
+++ b/.github/workflows/assignment-helper.yml
@@ -4,9 +4,10 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   assignment-helper:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-assignment-helper.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all  # default read; writes scoped to job below
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +18,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     if: >-
       github.event_name != 'pull_request_target' ||
       github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   feedback:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,11 +4,12 @@ on:
   issue_comment:
     types: [created]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   label-helper:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-label-helper.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4

--- a/.github/workflows/pr-verify-title.yml
+++ b/.github/workflows/pr-verify-title.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   verify:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-pr-verify-title.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4  # main

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,12 +7,13 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,9 +5,10 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
-permissions:
-  issues: write
+permissions: read-all  # default read; writes scoped to job below
 
 jobs:
   stale:
+    permissions:
+      issues: write
     uses: kubestellar/infra/.github/workflows/reusable-stale.yml@af322d48cc67ade7345cabc6a0ed55c6c7040ee4


### PR DESCRIPTION
## Fix

Moves write-level `GITHUB_TOKEN` permissions from workflow top-level to per-job blocks, and adds `permissions: read-all` at the top level as the default. This eliminates the `Token-Permissions` Scorecard score of 0 for these workflows.

### Affected workflows

| Workflow | Write permissions moved to job |
|----------|-------------------------------|
| `ai-fix.yml` | `contents`, `issues`, `pull-requests` |
| `copilot-automation.yml` | `contents`, `pull-requests`, `issues`, `statuses` |
| `scorecard.yml` | `security-events`, `id-token` |
| `add-help-wanted.yml` | `issues` |
| `assignment-helper.yml` | `issues` |
| `feedback.yml` | `pull-requests` |
| `label-helper.yml` | `issues`, `pull-requests` |
| `pr-verify-title.yml` | `pull-requests` |
| `stale.yml` | `issues` |

`pr-verifier.yml` and `greetings.yml` were already compliant.

Fixes #58

---
*Filed by scanner agent (ACMM L6 — automerge mode)*