### PR TITLE
fix: resolve brew audit formula failures

### DIFF
--- a/Formula/kubestellar-deploy.rb
+++ b/Formula/kubestellar-deploy.rb
@@ -45,6 +45,6 @@ class KubestellarDeploy < Formula
   end
 
   test do
-    system "#{bin}/kubestellar-deploy", "version"
+    system bin/"kubestellar-deploy", "version"
   end
 end

--- a/Formula/kubestellar-ops.rb
+++ b/Formula/kubestellar-ops.rb
@@ -45,6 +45,6 @@ class KubestellarOps < Formula
   end
 
   test do
-    system "#{bin}/kubestellar-ops", "version"
+    system bin/"kubestellar-ops", "version"
   end
 end


### PR DESCRIPTION
## Summary
- Fixes `brew audit --strict` failure in `kubestellar-deploy` formula (line 48)
- Also fixes the same issue in `kubestellar-ops` formula (proactive)
- Change: `"#{bin}/name"` -> `bin/"name"` in test blocks, per Homebrew style requirements

The CI error was:
```
Use `bin/"kubestellar-deploy"` instead of `"#{bin}/kubestellar-deploy"`
```

`kc-agent` already used the correct syntax.