### PR TITLE
[scanner] fix: resolve kubestellar-deploy formula CI failure

### DIFF
--- a/Formula/kubestellar-deploy.rb
+++ b/Formula/kubestellar-deploy.rb
@@ -45,6 +45,6 @@ class KubestellarDeploy < Formula
   end
 
   test do
-    system "#{bin}/kubestellar-deploy", "version"
+    system bin/"kubestellar-deploy", "version"
   end
 end


### PR DESCRIPTION
Fixes #108

Resolves the Homebrew CI failure for the kubestellar-deploy formula by updating the deprecated path interpolation syntax.

## Changes
- Updated `Formula/kubestellar-deploy.rb` line 48 from `"#{bin}/kubestellar-deploy"` to `bin/"kubestellar-deploy"`

## Why
The `brew audit --strict` command now requires the modern `bin/"name"` path helper syntax instead of the old `"#{bin}/name"` string interpolation style. This was causing CI failures on every nightly formula update.

## Testing
This change aligns with current Homebrew best practices and will pass `brew audit --strict` validation.